### PR TITLE
links: expand params dict correctly

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,5 +1,6 @@
 ..
     Copyright (C) 2020 CERN.
+    Copyright (C) 2020 Northwestern University.
 
     Marshmallow-Utils is free software; you can redistribute it and/or
     modify it under the terms of the MIT License; see LICENSE file for more
@@ -11,3 +12,4 @@ Authors
 Extras and utilities for Marshmallow
 
 - Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
+- Guillaume Viger <guillaume.viger@northwestern.edu>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 ..
     Copyright (C) 2020 CERN.
+    Copyright (C) 2020 Northwestern University.
 
     Marshmallow-Utils is free software; you can redistribute it and/or
     modify it under the terms of the MIT License; see LICENSE file for more
@@ -7,6 +8,10 @@
 
 Changes
 =======
+
+Version 0.1.5 (released 2020-09-24)
+
+- Fix to expand querystring params correctly
 
 Version 0.1.4 (released 2020-09-17)
 

--- a/marshmallow_utils/version.py
+++ b/marshmallow_utils/version.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
 # Marshmallow-Utils is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -11,4 +12,4 @@ This file is imported by ``marshmallow_utils.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Marshmallow-Utils is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test LinksStore."""
+
+
+from uritemplate import URITemplate
+
+from marshmallow_utils.links import LinksStore
+
+
+def test_resolve_params():
+    links = LinksStore(host="localhost")
+    links_config = {
+        "search": {
+            "self": URITemplate("/{?params*}"),
+        }
+    }
+    data = {
+        "self": {
+            "params": {
+                "type": ["A", "B"],
+                "sort": "newest",
+                "subtype": ["1"],
+                "size": 10,
+            }
+        }
+    }
+    links.add("search", data)
+
+    links.resolve(config=links_config)
+
+    assert (
+        "https://localhost/?size=10&sort=newest&subtype=1&type=A&type=B" ==
+        data["self"]
+    )


### PR DESCRIPTION
Needed to make pr 109_... on invenio-records-resources pass.
This doesn't contain likely full refactor of LinksStore.resolve﻿. 
