### PR TITLE
fields: create URITemplate from strings for Link

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@
 Changes
 =======
 
+Version 0.3.4 (released 2021-01-24)
+
+- Makes Link field a bit easier to use by allowing a string to be passed
+  in addition to an URITemplate.
+
 Version 0.3.3 (released 2021-01-20)
 
 - Adds support for automatic scheme detection on identifiers.

--- a/marshmallow_utils/fields/links.py
+++ b/marshmallow_utils/fields/links.py
@@ -8,6 +8,7 @@
 """Link store and field for generating links."""
 
 from marshmallow import fields, missing
+from uritemplate import URITemplate
 
 
 class Links(fields.Field):
@@ -43,6 +44,8 @@ class Link(fields.Field):
     def __init__(self, template=None, params=None, permission=None,
                  when=always, **kwargs):
         """Constructor."""
+        if isinstance(template, str):
+            template = URITemplate(template)
         self.template = template
         self.permission = permission
         self.params = params

--- a/marshmallow_utils/version.py
+++ b/marshmallow_utils/version.py
@@ -12,4 +12,4 @@ This file is imported by ``marshmallow_utils.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.3.3'
+__version__ = '0.3.4'

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -140,3 +140,10 @@ def test_when(my_schema):
     assert 'self' in links
     assert 'publish' in links
     assert 'prev' in links
+
+
+def test_link_field_initialization():
+    """Test that you can pass both URI templates and strings."""
+    tpls = ["/records{?params*}", URITemplate("/records{?params*})")]
+    for t in tpls:
+        assert isinstance(fields.Link(template=t).template, URITemplate)


### PR DESCRIPTION
* Makes Link field a bit easier to use by allowing a string to be passed
  instead of a URITemplate.