### PR TITLE
fields: add BabelGettextDictField

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 Changes
 =======
 
+Version 0.3.5 (released 2021-01-25)
+
+- Adds BabelGettextDictField for dumping translation strings from dicts.
+
 Version 0.3.4 (released 2021-01-24)
 
 - Makes Link field a bit easier to use by allowing a string to be passed

--- a/marshmallow_utils/fields/__init__.py
+++ b/marshmallow_utils/fields/__init__.py
@@ -7,7 +7,8 @@
 
 """Marshmallow fields."""
 
-from .babel import FormatDate, FormatDatetime, FormatEDTF, FormatTime
+from .babel import BabelGettextDictField, FormatDate, FormatDatetime, \
+    FormatEDTF, FormatTime
 from .contrib import Function, Method
 from .edtfdatestring import EDTFDateString
 from .generated import GenFunction, GenMethod
@@ -23,6 +24,7 @@ from .trimmed import TrimmedString
 __all__ = (
     'ALLOWED_HTML_ATTRS',
     'ALLOWED_HTML_TAGS',
+    'BabelGettextDictField',
     'EDTFDateString',
     'FormatDate',
     'FormatDatetime',

--- a/marshmallow_utils/fields/babel.py
+++ b/marshmallow_utils/fields/babel.py
@@ -11,6 +11,8 @@ import calendar
 from datetime import date, datetime
 
 import arrow
+from babel import Locale
+from babel.core import negotiate_locale
 from babel.dates import LC_TIME, format_date, format_datetime, format_time
 from babel_edtf import format_edtf
 from marshmallow import fields
@@ -120,3 +122,93 @@ class FormatEDTF(BabelFormatField):
     def format_value(self, value):
         """Format an EDTF date."""
         return format_edtf(value, format=self._format, locale=self.locale)
+
+
+class BabelGettextDictField(fields.String):
+    """Translation string field (dump only).
+
+    This field dumps a translation string as output, by looking up the
+    translation in the dictionary provided as input (the message catalog).
+
+    The lookup is performed via babel's locale negotiation (e.g. en_US will
+    also match en).
+
+    Basically the fields takes a data object like this::
+
+        {'title': {'en': 'Text', 'da': 'Tekst'}}
+
+    and dumps this (in case the locale is english)::
+
+        {'title': 'Text'}
+    """
+
+    default_error_messages = {
+        'invalid': 'Not a valid dictionary.',
+        'missing_locale': 'Translation not found for ',
+    }
+
+    def __init__(self, locale, default_locale, **kwargs):
+        """Initialize the field.
+
+        :param locale: The locale to lookup, or a function returning the
+            locale.
+        :param default_locale: The default locale in case the locale is not
+            found. Can be a callable that returns the default locale.
+        """
+        self._locale = locale
+        self._default_locale = default_locale
+        kwargs['dump_only'] = True
+        super().__init__(**kwargs)
+
+    @property
+    def locale(self):
+        """Get the locale to be used."""
+        return self._locale() if callable(self._locale) else self._locale
+
+    @property
+    def default_locale(self):
+        """Get the default locale to be used."""
+        return self._default_locale() \
+            if callable(self._default_locale) else self._default_locale
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        """Serialize the dict into a string.
+
+        The dict is a message catalog with the keys being locale identifiers
+        and the values being the translated string.
+        """
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise self.make_error('invalid')
+        translated_str = gettext_from_dict(
+            value, self.locale, self.default_locale)
+        if translated_str is None:
+            raise self.make_error('missing_locale')
+        return super()._serialize(translated_str, attr, obj, **kwargs)
+
+
+def gettext_from_dict(catalog, locale, default_locale):
+    """Get translation string from a dictionary."""
+    # First try with negotiate_locale. Negotiate locale will not properly
+    # negotiate e.g "en" when the available locales are "en_GB" and "da", even
+    # though "en_GB" could be used.
+    selected = negotiate_locale([str(locale)], catalog.keys())
+    if selected:
+        return catalog[selected]
+
+    # In situations where negotiate locale doesn't work, we check if the
+    # language itself might be found.
+
+    # Extract language keys only.
+    catalog_langs = {
+        Locale.parse(l).language: l for (l, msg) in catalog.items()
+    }
+    if isinstance(locale, str):
+        locale = Locale.parse(locale)
+    if locale.language in catalog_langs:
+        # If primary language match, use that
+        catalog_key = catalog_langs[locale.language]
+        return catalog[catalog_key]
+    # If not, use default locale (must be defined it is defined)
+    return catalog.get(str(default_locale), None)

--- a/marshmallow_utils/version.py
+++ b/marshmallow_utils/version.py
@@ -12,4 +12,4 @@ This file is imported by ``marshmallow_utils.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.3.4'
+__version__ = '0.3.5'


### PR DESCRIPTION
Adds as a new field, that produces translations strings  (dump only).

Basically the fields takes a data object like this::

```python
{'title': {'en': 'Text', 'da': 'Tekst'}}
```

and dumps this (in case the locale is english):

```
{'title': 'Text'}
```

It uses babel underlying locale negotiation feature.