### PR TITLE
error: use make_error instead of raising

### DIFF
--- a/marshmallow_utils/fields/identifier.py
+++ b/marshmallow_utils/fields/identifier.py
@@ -17,8 +17,12 @@ class IdentifierSet(List):
     It assumes the items of the list contain a *scheme* property.
     """
 
+    default_error_messages = {
+        "multiple_values": "Only one identifier per scheme is allowed.",
+    }
+
     def _validate(self, value):
         """Validates the list of identifiers."""
         schemes = [identifier["scheme"] for identifier in value]
         if not len(value) == len(set(schemes)):
-            raise ValidationError("Only one identifier per scheme is allowed.")
+            raise self.make_error(key="multiple_values")

--- a/marshmallow_utils/schemas/identifier.py
+++ b/marshmallow_utils/schemas/identifier.py
@@ -23,6 +23,12 @@ class IdentifierSchema(Schema):
     identifier = SanitizedUnicode()
     scheme = SanitizedUnicode()
 
+    error_messages = {
+        "invalid_identifier": "Invalid {scheme} identifier.",
+        "invalid_scheme": "Invalid scheme for identifier {identifier}.",
+        "required": "Missing data for required field.",
+    }
+
     def __init__(self, allowed_schemes, identifier_required=True, **kwargs):
         """Constructor.
 
@@ -31,12 +37,6 @@ class IdentifierSchema(Schema):
         :param identifier_required: True when the identifier value is required.
         """
         self.identifier_required = identifier_required
-
-        if not allowed_schemes:
-            raise ValidationError(
-                    "allowed_schemes must be a list of string(s) " +
-                    "and/or tuple(s)")
-
         self.allowed_schemes = allowed_schemes
         super().__init__(**kwargs)
 
@@ -81,12 +81,14 @@ class IdentifierSchema(Schema):
 
         if self.identifier_required and not identifier:
             raise ValidationError(
-                "Missing required identifier.", field_name="identifier"
+                self.error_messages["required"],
+                field_name="identifier"
             )
 
         if identifier and not scheme:
+            message = self.error_messages["invalid_scheme"]
             raise ValidationError(
-                f"Missing or invalid scheme for identifier {identifier}.",
+                message.format(identifier=identifier),
                 field_name="scheme"
             )
 
@@ -97,8 +99,9 @@ class IdentifierSchema(Schema):
                 scheme_label = self.allowed_schemes[scheme].get(
                     "label", scheme
                 )
+                message = self.error_messages["invalid_identifier"]
                 raise ValidationError(
-                    f"Invalid value {identifier} for scheme {scheme_label}.",
+                    message.format(scheme=scheme_label),
                     field_name="identifier"
                 )
 


### PR DESCRIPTION
- closes #44 

Checked the other fields and only the [ISOLangString has a validation check](https://github.com/inveniosoftware/marshmallow-utils/blob/master/marshmallow_utils/fields/isolanguage.py#L20). However, it is handled in an external function so it is "ok". I would suggest:

- Make that function return True/False
- Raise with `make_error`. That way, potential external uses of that function get a boolean response.
- What about the moneky patched translation in there? Shall we use this approach in the identifiers too?