### PR TITLE
babel: check if locale is not None before accessing its language

### DIFF
--- a/marshmallow_utils/fields/babel.py
+++ b/marshmallow_utils/fields/babel.py
@@ -206,7 +206,7 @@ def gettext_from_dict(catalog, locale, default_locale):
     }
     if isinstance(locale, str):
         locale = Locale.parse(locale)
-    if locale.language in catalog_langs:
+    if locale is not None and locale.language in catalog_langs:
         # If primary language match, use that
         catalog_key = catalog_langs[locale.language]
         return catalog[catalog_key]


### PR DESCRIPTION
Without this check, accessing `locale.language` will result in an exception, if `locale is None`.
This happens e.g. when trying to call [`invenio_app_rdm.records_ui.views.deposits.get_form_config`](https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/records_ui/views/deposits.py#L253) from `invenio-cli pyshell` for testing purposes.