### PR TITLE
identifiers: change error message for invalid identifier schemes

### DIFF
--- a/marshmallow_utils/schemas/identifier.py
+++ b/marshmallow_utils/schemas/identifier.py
@@ -23,6 +23,7 @@ class IdentifierSchema(Schema):
     scheme = SanitizedUnicode()
 
     error_messages = {
+        "unknown_scheme": "No valid scheme recognized for identifier.",
         "invalid_identifier": "Invalid {scheme} identifier.",
         "invalid_scheme": "Invalid scheme.",
         "required": "Missing data for required field.",
@@ -84,7 +85,9 @@ class IdentifierSchema(Schema):
         errors = dict()
 
         # Validate scheme
-        if not scheme:
+        if not scheme and identifier:
+            errors["scheme"] = self.error_messages["unknown_scheme"]
+        elif not scheme:
             errors["scheme"] = self.error_messages["required"]
         elif scheme not in self.allowed_schemes:
             errors["scheme"] = self.error_messages["invalid_scheme"]

--- a/tests/schemas/test_identifier_schema.py
+++ b/tests/schemas/test_identifier_schema.py
@@ -187,7 +187,7 @@ def test_detected_and_not_allowed_scheme_valid_value():  # 6
         schema.load(valid_doi)
 
     errors = e.value.normalized_messages()
-    assert errors == {"scheme": "Missing data for required field."}
+    assert errors == {"scheme": "No valid scheme recognized for identifier."}
 
 
 def test_detected_and_allowed_scheme_respect_detection_order():  # 8
@@ -222,4 +222,4 @@ def test_not_given_not_detected_scheme_for_identifier():  # 10
         schema.load(invalid_no_scheme)
 
     errors = e.value.normalized_messages()
-    assert errors == {"scheme": "Missing data for required field."}
+    assert errors == {"scheme": "No valid scheme recognized for identifier."}


### PR DESCRIPTION
Changed the error message for when you have an identifier but no scheme was identified, it will now give an invalid scheme error so that the user has a better idea of what went wrong. 


![Screenshot from 2022-07-26 10-25-26](https://user-images.githubusercontent.com/55200060/180960029-03ff334f-c10f-4996-885d-06495d0edb88.png)



closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1109

