### PR TITLE
gh-actions: install babel in pypi-publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel
+          pip install setuptools wheel babel
 
       - name: Build package
         run: |


### PR DESCRIPTION
- closes #64 

v0.5.6 has been released from `maint-v0.5` branch