### PR TITLE
permissions: cache permissions in the request

### DIFF
--- a/marshmallow_utils/permissions.py
+++ b/marshmallow_utils/permissions.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2023 CERN.
 #
 # Marshmallow-Utils is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Field-level permissions."""
 
-from marshmallow import INCLUDE, Schema, fields, post_dump, pre_load, validate
+from marshmallow import post_dump, pre_load
 
 
 class FieldPermissionError(Exception):
@@ -37,14 +37,16 @@ class FieldPermissionsMixin:
     @post_dump
     def _permissions_filter_dump(self, data, **kwargs):
         field_permission_check = self.context.get("field_permission_check")
-        # NOTE: we make a copy since we don't want to modify the data when
-        # deleting keys
-        # TODO (Alex): see if actually needed...
-        # data = deepcopy(data)
         if field_permission_check:
+            # Initialize permissions cache to avoid to re-compute permissions that are repeated
+            _permissions_cache = dict()
             for k in self.field_dump_permissions:
                 if k in data:
                     action = self.field_dump_permissions[k] or self.default_dump_action
-                    if action and not field_permission_check(action):
+                    has_permission = _permissions_cache.get(action)
+                    if not has_permission:
+                        has_permission = field_permission_check(action)
+                        _permissions_cache[action] = has_permission
+                    if action and not has_permission:
                         del data[k]
         return data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,51 @@
 """Pytest configuration."""
 
 import pytest
+from marshmallow import Schema, fields
+
+from marshmallow_utils.permissions import FieldPermissionsMixin
+
+
+class TestSchema(Schema, FieldPermissionsMixin):
+    """Test schema with field permissions."""
+
+    field_dump_permissions = {
+        "name": "read",
+        "last_name": "read",
+        "age": "read",
+        "address": "manage",
+    }
+
+    name = fields.String()
+    last_name = fields.String()
+    age = fields.Integer()
+    address = fields.String()
+
+
+class Test:
+    """Test class."""
+
+    def __init__(self, name, last_name, age, address):
+        """Constructor."""
+        self.name = name
+        self.last_name = last_name
+        self.age = age
+        self.address = address
+
+
+@pytest.fixture()
+def test_schema():
+    """Fixture to return the TestSchema class."""
+    return TestSchema
+
+
+@pytest.fixture()
+def test_object():
+    """Returns a simple test object."""
+    return Test("John", "Doe", 30, "CERN")
+
+
+@pytest.fixture()
+def test_object2():
+    """Returns a simple test object."""
+    return Test("Foo", "Bar", 40, "CERN")

--- a/tests/schemas/test_schema_permissions.py
+++ b/tests/schemas/test_schema_permissions.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 CERN.
+#
+# Marshmallow-Utils is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for marshmallow schema post dump permissions check."""
+
+
+def mocked_field_permission_check(action, identity=None, **kwargs):
+    """Mocked permission resolution."""
+    mocked_field_permission_check.counter += 1
+    if action == "read":
+        return True
+    elif action == "manage":
+        return False
+
+    return False
+
+
+def mocked_field_permission_check_allow_manage(action, identity=None, **kwargs):
+    """Mocked permission resolution allowing to manage."""
+    mocked_field_permission_check.counter += 1
+    if action == "read":
+        return True
+    elif action == "manage":
+        return True
+
+    return False
+
+
+def test_post_dump_permissions_removal(test_schema, test_object, test_object2):
+    """Test that some fields are removed based on the permissions level access of the user."""
+    mocked_field_permission_check.counter = 0  # We count the number of times the function is called because we are caching the return value in "_permissions_filter_dump" to increase the performance
+
+    test = test_schema(
+        context={"field_permission_check": mocked_field_permission_check}
+    ).dump(test_object)
+
+    assert test["name"] == "John"
+    assert test["last_name"] == "Doe"
+    assert test["age"] == 30
+    assert not test.get("address")
+
+    assert (
+        mocked_field_permission_check.counter == 2
+    )  # since only 2 different permissions are defined in the attribute "field_dump_permissions" of the schema, we should only resolve 2 times the permissions
+
+    mocked_field_permission_check.counter = 0  # We reset the counter
+
+    test = test_schema(
+        context={"field_permission_check": mocked_field_permission_check_allow_manage}
+    ).dump([test_object, test_object2], many=True)
+
+    assert len(test) == 2
+
+    # Now it simulates that the permission check logic allows us to see all the fields
+    assert test[0]["name"] == "John"
+    assert test[0]["last_name"] == "Doe"
+    assert test[0]["age"] == 30
+    assert test[0].get("address") == "CERN"
+
+    assert test[1]["name"] == "Foo"
+    assert test[1]["last_name"] == "Bar"
+    assert test[1]["age"] == 40
+    assert test[1].get("address") == "CERN"
+
+    assert (
+        mocked_field_permission_check.counter == 4
+    )  # since only 2 different permissions are defined in the attribute "field_dump_permissions" of the schema, we should only resolve 4 times the permissions (2 permissions checks * 2 different records)

--- a/tests/test_babel.py
+++ b/tests/test_babel.py
@@ -46,8 +46,8 @@ class MySchema(Schema):
 def test_format_edtf():
     """Test EDTF formatting."""
     assert MySchema().dump({"edtf": "2020-09/2020-10"}) == {
-        "short": "9/2020 – 10/2020",
-        "long": "September – October 2020",
+        "short": "9/2020\u2009–\u200910/2020",
+        "long": "September\u2009–\u2009October 2020",
     }
 
 

--- a/tests/test_isolanguage.py
+++ b/tests/test_isolanguage.py
@@ -18,11 +18,9 @@ class MySchema(Schema):
 
 
 def test_iso639_3_assert():
-
     assert MySchema().load({"f": "tes"}) == {"f": "tes"}
 
 
 @pytest.mark.parametrize("test_input", ["te", "12t", "te!", ",te!"])
 def test_iso639_3_raise(test_input):
-
     pytest.raises(ValidationError, MySchema().load, {"f": test_input})


### PR DESCRIPTION
* closes https://github.com/inveniosoftware/invenio-rdm-records/issues/1509

Perfomance increase is around 10% on the dump func.
Emulating high traffic (setting a sleep in the `allow` func for 30 ms ) on a search with 20 results the search is almost 50% faster. From 11 seconds to 6 seconds