### PR TITLE
fields: Add custom URL field with updated validator

### DIFF
--- a/marshmallow_utils/fields/__init__.py
+++ b/marshmallow_utils/fields/__init__.py
@@ -27,6 +27,7 @@ from .sanitizedunicode import SanitizedUnicode
 from .strippedhtml import StrippedHTML
 from .trimmed import TrimmedString
 from .tzdatetime import TZDateTime
+from .url import URL
 
 __all__ = (
     "ALLOWED_HTML_ATTRS",
@@ -52,4 +53,5 @@ __all__ = (
     "StrippedHTML",
     "TrimmedString",
     "TZDateTime",
+    "URL",
 )

--- a/marshmallow_utils/fields/url.py
+++ b/marshmallow_utils/fields/url.py
@@ -37,7 +37,10 @@ class URLValidator(Validator):
     """
 
     class RegexMemoizer:
+        """RegexMemoizer for URLValidator."""
+
         def __init__(self):
+            """Constructor."""
             self._memoized = {}
 
         def _regex_generator(
@@ -97,6 +100,7 @@ class URLValidator(Validator):
         def __call__(
             self, relative: bool, absolute: bool, require_tld: bool
         ) -> typing.Pattern:
+            """Generate, memoize and return validation regex."""
             key = (relative, absolute, require_tld)
             if key not in self._memoized:
                 self._memoized[key] = self._regex_generator(
@@ -119,6 +123,16 @@ class URLValidator(Validator):
         require_tld: bool = True,
         error: str | None = None,
     ):
+        """Constructor.
+
+        :param relative: Whether to allow relative URLs.
+        :param absolute: Whether to allow absolute URLs.
+        :param error: Error message to raise in case of a validation error.
+            Can be interpolated with `{input}`.
+        :param schemes: Valid schemes. By default, ``http``, ``https``,
+            ``ftp``, and ``ftps`` are allowed.
+        :param require_tld: Whether to reject non-FQDN hostnames.
+        """
         if not relative and not absolute:
             raise ValueError(
                 "URL validation cannot set both relative and absolute to False."
@@ -136,6 +150,10 @@ class URLValidator(Validator):
         return self.error.format(input=value)
 
     def __call__(self, value: str) -> str:
+        """Run the validation.
+
+        :param value: URL string to be validated.
+        """
         message = self._format_error(value)
         if not value:
             raise ValidationError(message)
@@ -177,6 +195,15 @@ class URL(String):
         require_tld: bool = True,
         **kwargs,
     ):
+        """Constructor.
+
+        :param default: Default value for the field if the attribute is not set.
+        :param relative: Whether to allow relative URLs.
+        :param require_tld: Whether to reject non-FQDN hostnames.
+        :param schemes: Valid schemes. By default, ``http``, ``https``,
+            ``ftp``, and ``ftps`` are allowed.
+        :param kwargs: The same keyword arguments that :class:`String` receives.
+        """
         super().__init__(**kwargs)
 
         self.relative = relative

--- a/marshmallow_utils/fields/url.py
+++ b/marshmallow_utils/fields/url.py
@@ -50,7 +50,7 @@ class URLValidator(Validator):
                 # a normal domain name, expressed in [A-Z0-9] chars with hyphens allowed only in the middle
                 # note that the regex will be compiled with IGNORECASE, so these are upper and lowercase chars
                 (
-                    r"(?:[A-Z0-9](?!.*[-_]{2})(?:[A-Z0-9-_]{0,61}[A-Z0-9])?\.)+"
+                    r"(?:[A-Z0-9](?!.*(-_|_-))(?:[A-Z0-9-_]{0,61}[A-Z0-9])?\.)+"
                     r"(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)"
                 ),
                 # or the special string 'localhost'

--- a/marshmallow_utils/fields/url.py
+++ b/marshmallow_utils/fields/url.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2016-2023 CERN.
+# Copyright 2021 Steven Loria and contributors
+#
+# Marshmallow-Utils is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Update URL field."""
+
+from __future__ import annotations
+
+import re
+import typing
+
+from marshmallow import types
+from marshmallow.exceptions import ValidationError
+from marshmallow.fields import String
+from marshmallow.validate import Validator
+
+
+class URLValidator(Validator):
+    """Validate a URL.
+
+    Marshmallow's URL validator doesn't allow underscores in subdomains.
+    https://github.com/marshmallow-code/marshmallow/blob/27294efc374d9a073386bb6aba807e9b7eb525f6/src/marshmallow/validate.py#L93
+    This validator allows underscores in the subdomains.
+
+
+    :param relative: Whether to allow relative URLs.
+    :param absolute: Whether to allow absolute URLs.
+    :param error: Error message to raise in case of a validation error.
+        Can be interpolated with `{input}`.
+    :param schemes: Valid schemes. By default, ``http``, ``https``,
+        ``ftp``, and ``ftps`` are allowed.
+    :param require_tld: Whether to reject non-FQDN hostnames.
+    """
+
+    class RegexMemoizer:
+        def __init__(self):
+            self._memoized = {}
+
+        def _regex_generator(
+            self, relative: bool, absolute: bool, require_tld: bool
+        ) -> typing.Pattern:
+            hostname_variants = [
+                # a normal domain name, expressed in [A-Z0-9] chars with hyphens allowed only in the middle
+                # note that the regex will be compiled with IGNORECASE, so these are upper and lowercase chars
+                (
+                    r"(?:[A-Z0-9](?!.*[-_]{2})(?:[A-Z0-9-_]{0,61}[A-Z0-9])?\.)+"
+                    r"(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)"
+                ),
+                # or the special string 'localhost'
+                r"localhost",
+                # or IPv4
+                r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}",
+                # or IPv6
+                r"\[[A-F0-9]*:[A-F0-9:]+\]",
+            ]
+            if not require_tld:
+                # allow dotless hostnames
+                hostname_variants.append(r"(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)")
+
+            absolute_part = "".join(
+                (
+                    # scheme (e.g. 'https://', 'ftp://', etc)
+                    # this is validated separately against allowed schemes, so in the regex
+                    # we simply want to capture its existence
+                    r"(?:[a-z0-9\.\-\+]*)://",
+                    # basic_auth, for URLs encoding a username:password
+                    # e.g. 'ftp://foo:bar@ftp.example.org/'
+                    r"(?:[^:@]+?(:[^:@]*?)?@|)",
+                    # netloc, the hostname/domain part of the URL plus the optional port
+                    r"(?:",
+                    "|".join(hostname_variants),
+                    r")",
+                    r"(?::\d+)?",
+                )
+            )
+            relative_part = r"(?:/?|[/?]\S+)\Z"
+
+            if relative:
+                if absolute:
+                    parts: tuple[str, ...] = (
+                        r"^(",
+                        absolute_part,
+                        r")?",
+                        relative_part,
+                    )
+                else:
+                    parts = (r"^", relative_part)
+            else:
+                parts = (r"^", absolute_part, relative_part)
+
+            return re.compile("".join(parts), re.IGNORECASE)
+
+        def __call__(
+            self, relative: bool, absolute: bool, require_tld: bool
+        ) -> typing.Pattern:
+            key = (relative, absolute, require_tld)
+            if key not in self._memoized:
+                self._memoized[key] = self._regex_generator(
+                    relative, absolute, require_tld
+                )
+
+            return self._memoized[key]
+
+    _regex = RegexMemoizer()
+
+    default_message = "Not a valid URL."
+    default_schemes = {"http", "https", "ftp", "ftps"}
+
+    def __init__(
+        self,
+        *,
+        relative: bool = False,
+        absolute: bool = True,
+        schemes: types.StrSequenceOrSet | None = None,
+        require_tld: bool = True,
+        error: str | None = None,
+    ):
+        if not relative and not absolute:
+            raise ValueError(
+                "URL validation cannot set both relative and absolute to False."
+            )
+        self.relative = relative
+        self.absolute = absolute
+        self.error = error or self.default_message  # type: str
+        self.schemes = schemes or self.default_schemes
+        self.require_tld = require_tld
+
+    def _repr_args(self) -> str:
+        return f"relative={self.relative!r}, absolute={self.absolute!r}"
+
+    def _format_error(self, value) -> str:
+        return self.error.format(input=value)
+
+    def __call__(self, value: str) -> str:
+        message = self._format_error(value)
+        if not value:
+            raise ValidationError(message)
+
+        # Check first if the scheme is valid
+        if "://" in value:
+            scheme = value.split("://")[0].lower()
+            if scheme not in self.schemes:
+                raise ValidationError(message)
+
+        regex = self._regex(self.relative, self.absolute, self.require_tld)
+
+        if not regex.search(value):
+            raise ValidationError(message)
+
+        return value
+
+
+class URL(String):
+    """URL field with custom URL validator.
+
+    :param default: Default value for the field if the attribute is not set.
+    :param relative: Whether to allow relative URLs.
+    :param require_tld: Whether to reject non-FQDN hostnames.
+    :param schemes: Valid schemes. By default, ``http``, ``https``,
+        ``ftp``, and ``ftps`` are allowed.
+    :param kwargs: The same keyword arguments that :class:`String` receives.
+    """
+
+    #: Default error messages.
+    default_error_messages = {"invalid": "Not a valid URL."}
+
+    def __init__(
+        self,
+        *,
+        relative: bool = False,
+        absolute: bool = True,
+        schemes: types.StrSequenceOrSet | None = None,
+        require_tld: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.relative = relative
+        self.absolute = absolute
+        self.require_tld = require_tld
+        # Insert validation into self.validators so that multiple errors can be stored.
+        validator = URLValidator(
+            relative=self.relative,
+            absolute=self.absolute,
+            schemes=schemes,
+            require_tld=self.require_tld,
+            error=self.error_messages["invalid"],
+        )
+        self.validators.insert(0, validator)

--- a/tests/fields/test_url.py
+++ b/tests/fields/test_url.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2016-2023 CERN.
+# Copyright 2021 Steven Loria and contributors
+#
+# Marshmallow-Utils is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for fields.url"""
+
+import re
+
+import pytest
+from marshmallow import ValidationError, validate
+
+from marshmallow_utils.fields.url import URLValidator
+
+
+@pytest.mark.parametrize(
+    "valid_url",
+    [
+        "http://example.org",
+        "https://example.org",
+        "ftp://example.org",
+        "ftps://example.org",
+        "http://example.co.jp",
+        "http://www.example.com/a%C2%B1b",
+        "http://www.example.com/~username/",
+        "http://info.example.com/?fred",
+        "http://xn--mgbh0fb.xn--kgbechtv/",
+        "http://example.com/blue/red%3Fand+green",
+        "http://www.example.com/?array%5Bkey%5D=value",
+        "http://xn--rsum-bpad.example.org/",
+        "http://123.45.67.8/",
+        "http://123.45.67.8:8329/",
+        "http://[2001:db8::ff00:42]:8329",
+        "http://[2001::1]:8329",
+        "http://www.example.com:8000/foo",
+        "http://user@example.com",
+        "http://user:pass@example.com",
+        "http://xn__mgbh0fb.xn--kgbechtv/",
+        "http://xn__mg--bh__0fb.xn--kgbechtv/",
+    ],
+)
+def test_url_absolute_valid(valid_url):
+    validator = URLValidator(relative=False)
+    assert validator(valid_url) == valid_url
+
+
+@pytest.mark.parametrize(
+    "invalid_url",
+    [
+        "http:///example.com/",
+        "https:///example.com/",
+        "https://example.org\\",
+        "https://example.org\n",
+        "ftp:///example.com/",
+        "ftps:///example.com/",
+        "http//example.org",
+        "http:///",
+        "http:/example.org",
+        "foo://example.org",
+        "../icons/logo.gif",
+        "http://2001:db8::ff00:42:8329",
+        "http://[192.168.1.1]:8329",
+        "http://xn_-mgbh0fb.xn--kgbechtv/",
+        "http://xn-_mg--bh__0fb.xn--kgbechtv/",
+        "http://-example.co.jp",
+        "http://_example.co.jp",
+        "http://example-.co.jp",
+        "http://example_.co.jp",
+        "abc",
+        "..",
+        "/",
+        " ",
+        "",
+        None,
+    ],
+)
+def test_url_absolute_invalid(invalid_url):
+    validator = URLValidator(relative=False)
+    with pytest.raises(ValidationError):
+        validator(invalid_url)
+
+
+@pytest.mark.parametrize(
+    "valid_url",
+    [
+        "http://example.org",
+        "http://123.45.67.8/",
+        "http://example.com/foo/bar/../baz",
+        "https://example.com/../icons/logo.gif",
+        "http://example.com/./icons/logo.gif",
+        "ftp://example.com/../../../../g",
+        "http://example.com/g?y/./x",
+        "/foo/bar",
+        "/foo?bar",
+        "/foo?bar#baz",
+    ],
+)
+def test_url_relative_valid(valid_url):
+    validator = URLValidator(relative=True)
+    assert validator(valid_url) == valid_url
+
+
+@pytest.mark.parametrize(  # noqa: W605
+    "invalid_url",
+    [
+        "http//example.org",
+        "http://example.org\n",
+        "suppliers.html",
+        "../icons/logo.gif",
+        "icons/logo.gif",
+        "../.../g",
+        "...",
+        "\\",
+        " ",
+        "",
+        None,
+    ],
+)
+def test_url_relative_invalid(invalid_url):
+    validator = URLValidator(relative=True)
+    with pytest.raises(ValidationError):
+        validator(invalid_url)
+
+
+@pytest.mark.parametrize(
+    "valid_url",
+    [
+        "/foo/bar",
+        "/foo?bar",
+        "?bar",
+        "/foo?bar#baz",
+    ],
+)
+def test_url_relative_only_valid(valid_url):
+    validator = URLValidator(relative=True, absolute=False)
+    assert validator(valid_url) == valid_url
+
+
+@pytest.mark.parametrize(
+    "invalid_url",
+    [
+        "http//example.org",
+        "http://example.org\n",
+        "suppliers.html",
+        "../icons/logo.gif",
+        "icons/logo.gif",
+        "../.../g",
+        "...",
+        "\\",
+        " ",
+        "",
+        "http://example.org",
+        "http://123.45.67.8/",
+        "http://example.com/foo/bar/../baz",
+        "https://example.com/../icons/logo.gif",
+        "http://example.com/./icons/logo.gif",
+        "ftp://example.com/../../../../g",
+        "http://example.com/g?y/./x",
+    ],
+)
+def test_url_relative_only_invalid(invalid_url):
+    validator = URLValidator(relative=True, absolute=False)
+    with pytest.raises(ValidationError):
+        validator(invalid_url)
+
+
+@pytest.mark.parametrize(
+    "valid_url",
+    [
+        "http://example.org",
+        "http://123.45.67.8/",
+        "http://example",
+        "http://example.",
+        "http://example:80",
+        "http://user.name:pass.word@example",
+        "http://example/foo/bar",
+    ],
+)
+def test_url_dont_require_tld_valid(valid_url):
+    validator = URLValidator(require_tld=False)
+    assert validator(valid_url) == valid_url
+
+
+@pytest.mark.parametrize(
+    "invalid_url",
+    [
+        "http//example",
+        "http://example\n",
+        "http://.example.org",
+        "http:///foo/bar",
+        "http:// /foo/bar",
+        "",
+        None,
+    ],
+)
+def test_url_dont_require_tld_invalid(invalid_url):
+    validator = URLValidator(require_tld=False)
+    with pytest.raises(ValidationError):
+        validator(invalid_url)
+
+
+def test_url_custom_scheme():
+    validator = URLValidator()
+    # By default, ws not allowed
+    url = "ws://test.test"
+    with pytest.raises(ValidationError):
+        validator(url)
+
+    validator = URLValidator(schemes={"http", "https", "ws"})
+    assert validator(url) == url
+
+
+def test_url_relative_and_custom_schemes():
+    validator = URLValidator(relative=True)
+    # By default, ws not allowed
+    url = "ws://test.test"
+    with pytest.raises(ValidationError):
+        validator(url)
+
+    validator = URLValidator(relative=True, schemes={"http", "https", "ws"})
+    assert validator(url) == url
+
+
+def test_url_custom_message():
+    validator = URLValidator(error="{input} ain't an URL")
+    with pytest.raises(ValidationError, match="invalid ain't an URL"):
+        validator("invalid")
+
+
+def test_url_repr():
+    assert repr(
+        URLValidator(relative=False, error=None)
+    ) == "<URLValidator(relative=False, absolute=True, error={!r})>".format(
+        "Not a valid URL."
+    )
+    assert repr(
+        URLValidator(relative=True, error="foo")
+    ) == "<URLValidator(relative=True, absolute=True, error={!r})>".format("foo")
+    assert repr(
+        URLValidator(relative=True, absolute=False, error="foo")
+    ) == "<URLValidator(relative=True, absolute=False, error={!r})>".format("foo")
+
+
+def test_url_rejects_invalid_relative_usage():
+    with pytest.raises(
+        ValueError,
+        match="URL validation cannot set both relative and absolute to False",
+    ):
+        URLValidator(relative=False, absolute=False)


### PR DESCRIPTION
### Description

Closes https://github.com/zenodo/rdm-project/issues/423

Marshmallow's [URL validator](https://github.com/marshmallow-code/marshmallow/blob/27294efc374d9a073386bb6aba807e9b7eb525f6/src/marshmallow/validate.py#L93) doesn't allow `_` in a subdomains. This PR implements a custom validator and field with just modified regex to allow `_` in subdomains.

Most of the code is exactly as is from:
- https://github.com/marshmallow-code/marshmallow/blob/27294efc374d9a073386bb6aba807e9b7eb525f6/src/marshmallow/validate.py
- https://github.com/marshmallow-code/marshmallow/blob/27294efc374d9a073386bb6aba807e9b7eb525f6/src/marshmallow/fields.py

Required copyright has been added as required.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
