### PR TITLE
fields: configure edtfdatestring field to disallow DateAndTime

### DIFF
--- a/marshmallow_utils/fields/__init__.py
+++ b/marshmallow_utils/fields/__init__.py
@@ -15,7 +15,7 @@ from .babel import (
     FormatTime,
 )
 from .contrib import Function, Method
-from .edtfdatestring import EDTFDateString
+from .edtfdatestring import EDTFDateString, EDTFDateTimeString
 from .generated import GenFunction, GenMethod
 from .identifier import IdentifierSet
 from .isodate import ISODateString
@@ -34,6 +34,7 @@ __all__ = (
     "ALLOWED_HTML_TAGS",
     "BabelGettextDictField",
     "EDTFDateString",
+    "EDTFDateTimeString",
     "FormatDate",
     "FormatDatetime",
     "FormatEDTF",

--- a/marshmallow_utils/fields/edtfdatestring.py
+++ b/marshmallow_utils/fields/edtfdatestring.py
@@ -61,9 +61,22 @@ class EDTFValidator(Validator):
 
 class EDTFDateString(fields.Str):
     """
+    Extended Date Format Level 0 date string field.
+
+    A string field which is using the EDTF Validator.
+    """
+
+    def __init__(self, **kwargs):
+        """Constructor."""
+        kwargs.setdefault("validate", EDTFValidator(types=[Date, Interval]))
+        super().__init__(**kwargs)
+
+
+class EDTFDateTimeString(fields.Str):
+    """
     Extended Date(/Time) Format Level 0 date string field.
 
-    A string field which an using the EDTF Validator.
+    A string field which is using the EDTF Validator.
     """
 
     def __init__(self, **kwargs):

--- a/tests/test_edtfdatestring.py
+++ b/tests/test_edtfdatestring.py
@@ -10,32 +10,45 @@
 import pytest
 from marshmallow import Schema, ValidationError
 
-from marshmallow_utils.fields import EDTFDateString
+from marshmallow_utils.fields import EDTFDateString, EDTFDateTimeString
 
 
-class TestSchema(Schema):
+class TestSchemaDate(Schema):
     date = EDTFDateString()
 
 
-def test_dump():
-    assert TestSchema().dump({"date": "2020-09/2020-10"}) == {
+class TestSchemaDateTime(Schema):
+    datetime = EDTFDateTimeString()
+
+
+def test_dump_date():
+    assert TestSchemaDate().dump({"date": "2020-09/2020-10"}) == {
         "date": "2020-09/2020-10",
     }
-    # dump datetime
-    assert TestSchema().dump({"date": "2020-01-01T10:00:00"}) == {
-        "date": "2020-01-01T10:00:00",
+
+
+def test_dump_datetime():
+    assert TestSchemaDateTime().dump({"datetime": "2020-01-01T10:00:00"}) == {
+        "datetime": "2020-01-01T10:00:00",
     }
 
 
-def test_load():
-    s = TestSchema()
+def test_load_date():
+    s = TestSchemaDate()
     assert s.load({"date": "2020-09/2020-10"})
-    assert s.load({"date": "2020-01-01T10:00:00"})
+    assert s.load({"date": "2020-01-01"})
     # Invalid
     pytest.raises(ValidationError, s.load, {"date": "2020-09-21garbage"})
     # Not chronological
     pytest.raises(ValidationError, s.load, {"date": "2021/2020"})
+    # Interval not supported
+    pytest.raises(ValidationError, s.load, {"date": "2020-01-01T10:00:00"})
+
+
+def test_load_datetime():
+    s = TestSchemaDateTime()
+    assert s.load({"datetime": "2020-01-01T10:00:00"})
     # Invalid interval
     pytest.raises(
-        ValidationError, s.load, {"date": "2020-01-01T10:00:00/2020-02-01T10:00:00"}
+        ValidationError, s.load, {"datetime": "2020-01-01T10:00:00/2020-02-01T10:00:00"}
     )


### PR DESCRIPTION
* closes https://github.com/zenodo/rdm-project/issues/558

Allows to validate EDTF string for DateAndTime format in the step of parsing.
Won't let create an invalid `publication_date` 
<img width="1132" alt="Screenshot 2023-11-20 at 14 17 27" src="https://github.com/inveniosoftware/marshmallow-utils/assets/61321254/13f81316-2d57-435e-bb18-1258e91624e0">
