### PR TITLE
fix: missing locale

### DIFF
--- a/marshmallow_utils/fields/babel.py
+++ b/marshmallow_utils/fields/babel.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2016-2024 CERN.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Marshmallow-Utils is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -208,4 +208,11 @@ def gettext_from_dict(catalog, locale, default_locale):
             return catalog[catalog_key]
     # If not, use default locale (must be defined it is defined)
     # "en" is set as fallback language.
-    return catalog.get(str(default_locale)) or catalog.get("en")
+    out = catalog.get(str(default_locale)) or catalog.get("en")
+    if out:
+        return out
+
+    # if all other things didn't worked, we are here, the real and only last
+    # option, use the first element in the dictionary. this one here is only
+    # used to not break frontend
+    return list(catalog.values())[0]


### PR DESCRIPTION
it exists the possibility that Award [here](https://github.com/inveniosoftware/invenio-vocabularies/blob/master/invenio_vocabularies/contrib/awards/serializer.py#L37) cannot serialize `title` because the title has been added manually. manually adding the title uses the `locale preference` under the `profile` configuration to determine the "correct" translation key. this can create a situation where the `locale preference` is `de`, the site page is then set to `en` and the page can't be rendered because there is no `en` translation for `title` in the metadata of the record. this breaks among other things the search page.

the question is now how should that be fixed. the easiest solution for now is to merge this PR. it returns, if there is a value in the dictionary. it will return something.

the question is: if we don't use this PR, where do we provide a solution for the `missing_locale` raise [here](https://github.com/inveniosoftware/marshmallow-utils/blob/master/marshmallow_utils/fields/babel.py#L184) 