### PR TITLE
fix: remove usage of context

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,4 +10,4 @@ jobs:
     uses: inveniosoftware/workflows/.github/workflows/pypi-publish.yml@master
     secrets: inherit
     with:
-      babel-compile-catalog: false
+      babel-compile-catalog: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020-2024 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -18,40 +18,14 @@ on:
       - master
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 3 * * 6'
+    - cron:  "0 3 * * 6"
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Reason'
+        description: "Reason"
         required: false
-        default: 'Manual trigger'
+        default: "Manual trigger"
 
 jobs:
   Tests:
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-          python-version: ['3.9', '3.10', '3.11', '3.12']
-          requirements_level: [pypi]
-
-    env:
-      EXTRAS: tests
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: setup.cfg
-
-      - name: Install dependencies
-        run: |
-          pip install -e .[$EXTRAS]
-          pip freeze
-
-      - name: Run tests
-        run: |
-          ./run-tests.sh
+    uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master

--- a/marshmallow_utils/context.py
+++ b/marshmallow_utils/context.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Graz University of Technology.
+#
+# Marshmallow-Utils is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Context."""
+
+from contextvars import ContextVar
+
+context_schema: ContextVar[dict] = ContextVar("context_schema")

--- a/marshmallow_utils/fields/links.py
+++ b/marshmallow_utils/fields/links.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Marshmallow-Utils is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Link store and field for generating links."""
 
+from warnings import warn
+
 from marshmallow import fields, missing
 from uritemplate import URITemplate
+
+from ..context import context_schema
 
 
 class Links(fields.Field):
@@ -53,8 +58,23 @@ class Link(fields.Field):
 
     def _serialize(self, value, attr, obj, *args, **kwargs):
         """Dump the link by using the context."""
-        factory = self.context.get("links_factory")
-        field_permission_check = self.context.get("field_permission_check")
+        if "links_factory" in self.context:
+            warn(
+                "using self.context for links_factory is deprecated, use marshmallow_utils.context:context_schema for it.",
+                DeprecationWarning,
+            )
+            factory = self.context.get("links_factory")
+        else:
+            factory = context_schema.get()["links_factory"]
+
+        if "field_permission_check" in self.context:
+            warn(
+                "using self.context for field_permission_check is deprecated, use marshmallow_utils.context:context_schema for it.",
+                DeprecationWarning,
+            )
+            field_permission_check = self.context.get("field_permission_check")
+        else:
+            field_permission_check = context_schema.get()["field_permission_check"]
 
         if field_permission_check and self.permission:
             if not field_permission_check(self.permission):

--- a/marshmallow_utils/permissions.py
+++ b/marshmallow_utils/permissions.py
@@ -1,13 +1,18 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2023 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Marshmallow-Utils is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Field-level permissions."""
 
+from warnings import warn
+
 from marshmallow import post_dump, pre_load
+
+from .context import context_schema
 
 
 class FieldPermissionError(Exception):
@@ -24,7 +29,15 @@ class FieldPermissionsMixin:
 
     @pre_load
     def _permissions_filter_load(self, data, **kwargs):
-        field_permission_check = self.context.get("field_permission_check")
+        if "field_permission_check" in self.context:
+            warn(
+                "using self.context for field_permission_check is deprecated, use marshmallow_utils.context:context_schema for it.",
+                DeprecationWarning,
+            )
+            field_permission_check = self.context.get("field_permission_check")
+        else:
+            field_permission_check = context_schema.get()["field_permission_check"]
+
         if field_permission_check:
             for k in self.field_load_permissions:
                 if k in data:
@@ -36,7 +49,15 @@ class FieldPermissionsMixin:
 
     @post_dump
     def _permissions_filter_dump(self, data, **kwargs):
-        field_permission_check = self.context.get("field_permission_check")
+        if "field_permission_check" in self.context:
+            warn(
+                "using self.context for field_permission_check is deprecated, use marshmallow_utils.context:context_schema for it.",
+                DeprecationWarning,
+            )
+            field_permission_check = self.context.get("field_permission_check")
+        else:
+            field_permission_check = context_schema.get()["field_permission_check"]
+
         if field_permission_check:
             # Initialize permissions cache to avoid to re-compute permissions that are repeated
             _permissions_cache = dict()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Marshmallow-Utils is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -10,7 +11,17 @@
 import pytest
 from marshmallow import Schema, fields
 
-from marshmallow_utils.permissions import FieldPermissionsMixin
+from marshmallow_utils.permissions import FieldPermissionsMixin, context_schema
+
+
+@pytest.fixture
+def field_permission_check():
+    """Fixture for field permission check."""
+
+    def _permission_check(*args, **kwargs):
+        return True
+
+    context_schema.set({"field_permission_check": _permission_check})
 
 
 class TestSchema(Schema, FieldPermissionsMixin):

--- a/tests/schemas/test_schema_permissions.py
+++ b/tests/schemas/test_schema_permissions.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2023 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Marshmallow-Utils is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Tests for marshmallow schema post dump permissions check."""
+
+import pytest
+
+from marshmallow_utils.context import context_schema
 
 
 def mocked_field_permission_check(action, identity=None, **kwargs):
@@ -34,9 +39,10 @@ def test_post_dump_permissions_removal(test_schema, test_object, test_object2):
     """Test that some fields are removed based on the permissions level access of the user."""
     mocked_field_permission_check.counter = 0  # We count the number of times the function is called because we are caching the return value in "_permissions_filter_dump" to increase the performance
 
-    test = test_schema(
-        context={"field_permission_check": mocked_field_permission_check}
-    ).dump(test_object)
+    with pytest.warns(DeprecationWarning):
+        test = test_schema(
+            context={"field_permission_check": mocked_field_permission_check}
+        ).dump(test_object)
 
     assert test["name"] == "John"
     assert test["last_name"] == "Doe"
@@ -49,9 +55,53 @@ def test_post_dump_permissions_removal(test_schema, test_object, test_object2):
 
     mocked_field_permission_check.counter = 0  # We reset the counter
 
-    test = test_schema(
-        context={"field_permission_check": mocked_field_permission_check_allow_manage}
-    ).dump([test_object, test_object2], many=True)
+    with pytest.warns(DeprecationWarning):
+        test = test_schema(
+            context={
+                "field_permission_check": mocked_field_permission_check_allow_manage
+            }
+        ).dump([test_object, test_object2], many=True)
+
+    assert len(test) == 2
+
+    # Now it simulates that the permission check logic allows us to see all the fields
+    assert test[0]["name"] == "John"
+    assert test[0]["last_name"] == "Doe"
+    assert test[0]["age"] == 30
+    assert test[0].get("address") == "CERN"
+
+    assert test[1]["name"] == "Foo"
+    assert test[1]["last_name"] == "Bar"
+    assert test[1]["age"] == 40
+    assert test[1].get("address") == "CERN"
+
+    assert (
+        mocked_field_permission_check.counter == 4
+    )  # since only 2 different permissions are defined in the attribute "field_dump_permissions" of the schema, we should only resolve 4 times the permissions (2 permissions checks * 2 different records)
+
+
+def test_post_dump_permissions_removal_context(test_schema, test_object, test_object2):
+    """Test that some fields are removed based on the permissions level access of the user."""
+    mocked_field_permission_check.counter = 0  # We count the number of times the function is called because we are caching the return value in "_permissions_filter_dump" to increase the performance
+
+    context_schema.set({"field_permission_check": mocked_field_permission_check})
+    test = test_schema().dump(test_object)
+
+    assert test["name"] == "John"
+    assert test["last_name"] == "Doe"
+    assert test["age"] == 30
+    assert not test.get("address")
+
+    assert (
+        mocked_field_permission_check.counter == 2
+    )  # since only 2 different permissions are defined in the attribute "field_dump_permissions" of the schema, we should only resolve 2 times the permissions
+
+    mocked_field_permission_check.counter = 0  # We reset the counter
+
+    context_schema.set(
+        {"field_permission_check": mocked_field_permission_check_allow_manage}
+    )
+    test = test_schema().dump([test_object, test_object2], many=True)
 
     assert len(test) == 2
 


### PR DESCRIPTION
* this enables to migrate to marshmallow>=4.0

* partly super seeded by #103 which includes the utcnow -> now migration, but since it is not clear yet, if both things are done combined, i let this one open