### PR TITLE
fix(build): include mo files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,11 @@ encoding = "utf-8"
 [tool.hatch.version]
 path = "marshmallow_utils/__init__.py"
 
+[tool.hatch.build]
+artifacts = [
+  "*.mo",
+]
+
 [tool.hatch.build.targets.sdist]
 include = [
   "/marshmallow_utils",


### PR DESCRIPTION
* hatchling uses .gitignore to ignore files on build step. .mo files are
  in .gitignore but should be in the tar.gz file
